### PR TITLE
Camera adjustment

### DIFF
--- a/GrimsCoffinProject/Assets/Scenes/Noah's Test Scenes/NewTileLevelDesign.unity
+++ b/GrimsCoffinProject/Assets/Scenes/Noah's Test Scenes/NewTileLevelDesign.unity
@@ -1190,6 +1190,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   hasPlayer: 0
+  Border: {fileID: 857684612}
+  VCamera: {fileID: 1036461433}
 --- !u!114 &454498920
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1390,11 +1392,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4894866827985537568, guid: 3901873f192e26840810d12d84daf40c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -19.4
+      value: 62.7
       objectReference: {fileID: 0}
     - target: {fileID: 4894866827985537568, guid: 3901873f192e26840810d12d84daf40c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.7
+      value: 22.5
       objectReference: {fileID: 0}
     - target: {fileID: 4894866827985537568, guid: 3901873f192e26840810d12d84daf40c, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8836,6 +8838,146 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2406e437cb177064db0e3fba36099eee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &857684612
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 857684613}
+  - component: {fileID: 857684615}
+  - component: {fileID: 857684614}
+  m_Layer: 0
+  m_Name: Room 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &857684613
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 857684612}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 192.5552, y: -16.5728, z: 0.37120095}
+  m_LocalScale: {x: 178.39885, y: 76.38596, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1871410048}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!60 &857684614
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 857684612}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: -0.18502003, y: 0.36660612}
+      - {x: -0.18501808, y: 0.1781118}
+      - {x: -0.46240094, y: 0.17851643}
+      - {x: -0.46305886, y: -0.08625348}
+      - {x: -0.4033334, y: -0.08684766}
+      - {x: -0.40341344, y: -0.3888446}
+      - {x: 0.29241252, y: -0.39011043}
+      - {x: 0.29231256, y: 0.09436461}
+      - {x: 0.39323318, y: 0.09666479}
+      - {x: 0.39374572, y: 0.36520085}
+  m_UseDelaunayMesh: 0
+--- !u!212 &857684615
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 857684612}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1001 &915248983
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -49432,6 +49574,96 @@ Transform:
   - {fileID: 583467431}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1036461432
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1036461434}
+  - component: {fileID: 1036461433}
+  - component: {fileID: 1036461435}
+  m_Layer: 0
+  m_Name: FollowCam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1036461433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036461432}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 584877824}
+  m_Lens:
+    FieldOfView: 60
+    OrthographicSize: 7
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    FocusDistance: 10
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 2045668497}
+--- !u!4 &1036461434
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036461432}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 62.7, y: 22.5, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2045668497}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1036461435
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036461432}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2fba25a5cd15594e8f050a11e386c80, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ConfineMode: 0
+  m_BoundingVolume: {fileID: 0}
+  m_BoundingShape2D: {fileID: 1971515071}
+  m_ConfineScreenEdges: 1
+  m_Damping: 0
 --- !u!1001 &1049349497
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -49948,6 +50180,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   hasPlayer: 1
+  Border: {fileID: 1971515070}
+  VCamera: {fileID: 1036461433}
 --- !u!114 &1150608255
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -128703,6 +128937,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2406e437cb177064db0e3fba36099eee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1394500788 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7399055257594099030, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
+  m_PrefabInstance: {fileID: 1866543868}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1429619684
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -129884,7 +130123,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5161707832729600314, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
   m_PrefabInstance: {fileID: 1866543868}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 1394500788}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6867ba73de2fb2b429d464b517174d8f, type: 3}
@@ -130119,7 +130358,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 916537071340474138, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       propertyPath: orthographic size
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 1933030890750523246, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       propertyPath: m_RenderPostProcessing
@@ -130131,11 +130370,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5158343782362898515, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 70.9
+      value: 62.7
       objectReference: {fileID: 0}
     - target: {fileID: 5158343782362898515, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 14
+      value: 22.5
       objectReference: {fileID: 0}
     - target: {fileID: 5158343782362898515, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       propertyPath: m_LocalPosition.z
@@ -130203,13 +130442,217 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 5158343782362898515, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2129160385}
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7399055257594099030, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1866543872}
   m_SourcePrefab: {fileID: 100100000, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
 --- !u!4 &1866543869 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5158343782362898515, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
   m_PrefabInstance: {fileID: 1866543868}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1866543872
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1394500788}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72ece51f2901e7445ab60da3685d6b5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowDebugText: 0
+  m_ShowCameraFrustum: 1
+  m_IgnoreTimeScale: 0
+  m_WorldUpOverride: {fileID: 0}
+  m_UpdateMethod: 2
+  m_BlendUpdateMethod: 1
+  m_DefaultBlend:
+    m_Style: 1
+    m_Time: 2
+    m_CustomCurve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  m_CustomBlends: {fileID: 0}
+  m_CameraCutEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CameraActivatedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &1871410047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1871410048}
+  m_Layer: 0
+  m_Name: CameraBorder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1871410048
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1871410047}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.0319953, y: 19.973717, z: -0.37120095}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1971515073}
+  - {fileID: 857684613}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1971515070
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1971515073}
+  - component: {fileID: 1971515072}
+  - component: {fileID: 1971515071}
+  m_Layer: 0
+  m_Name: Room 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!60 &1971515071
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971515070}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: -0.40354386, y: 0.35968864}
+      - {x: -0.40495542, y: -0.41885608}
+      - {x: 0.36684352, y: -0.4146298}
+      - {x: 0.36496136, y: 0.3579981}
+  m_UseDelaunayMesh: 0
+--- !u!212 &1971515072
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971515070}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1971515073
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971515070}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 20.768003, y: -13.753616, z: 0.37120095}
+  m_LocalScale: {x: 134.08406, y: 74.639404, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1871410048}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1979620341
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -130554,6 +130997,119 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2406e437cb177064db0e3fba36099eee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &2045668496
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2045668497}
+  - component: {fileID: 2045668500}
+  - component: {fileID: 2045668499}
+  - component: {fileID: 2045668498}
+  - component: {fileID: 2045668501}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2045668497
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2045668496}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1036461434}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2045668498
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2045668496}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa7155796051b734daa718462081dc5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 1
+  m_FollowOffset: {x: 0, y: 0, z: -10}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0
+--- !u!114 &2045668499
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2045668496}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0.5
+  m_VerticalDamping: 0.5
+  m_ScreenX: 0.5
+  m_ScreenY: 0.5
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &2045668500
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2045668496}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2045668501
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2045668496}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68bb026fafb42b14791938953eaace77, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_NoiseProfile: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4, type: 2}
+  m_PivotOffset: {x: 0, y: 0, z: 0}
+  m_AmplitudeGain: 1
+  m_FrequencyGain: 0
+  mNoiseOffsets: {x: 0, y: 0, z: 0}
 --- !u!1001 &2072389248
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -130811,3 +131367,5 @@ SceneRoots:
   - {fileID: 1223654291}
   - {fileID: 82462589}
   - {fileID: 1082573158}
+  - {fileID: 1036461434}
+  - {fileID: 1871410048}

--- a/GrimsCoffinProject/Assets/Scenes/Noah's Test Scenes/NewTileLevelDesign.unity
+++ b/GrimsCoffinProject/Assets/Scenes/Noah's Test Scenes/NewTileLevelDesign.unity
@@ -1392,11 +1392,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4894866827985537568, guid: 3901873f192e26840810d12d84daf40c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 62.7
+      value: -15.7
       objectReference: {fileID: 0}
     - target: {fileID: 4894866827985537568, guid: 3901873f192e26840810d12d84daf40c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 22.5
+      value: -2.1
       objectReference: {fileID: 0}
     - target: {fileID: 4894866827985537568, guid: 3901873f192e26840810d12d84daf40c, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8923,8 +8923,8 @@ PolygonCollider2D:
       - {x: -0.40341344, y: -0.3888446}
       - {x: 0.29241252, y: -0.39011043}
       - {x: 0.29231256, y: 0.09436461}
-      - {x: 0.39323318, y: 0.09666479}
-      - {x: 0.39374572, y: 0.36520085}
+      - {x: 0.3968565, y: 0.09666479}
+      - {x: 0.39872795, y: 0.36520085}
   m_UseDelaunayMesh: 0
 --- !u!212 &857684615
 SpriteRenderer:
@@ -49640,7 +49640,7 @@ Transform:
   m_GameObject: {fileID: 1036461432}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 62.7, y: 22.5, z: -10}
+  m_LocalPosition: {x: -15.7, y: -2.1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -130370,11 +130370,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5158343782362898515, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 62.7
+      value: -14.956107
       objectReference: {fileID: 0}
     - target: {fileID: 5158343782362898515, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 22.5
+      value: -2.102415
       objectReference: {fileID: 0}
     - target: {fileID: 5158343782362898515, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       propertyPath: m_LocalPosition.z
@@ -130581,8 +130581,16 @@ PolygonCollider2D:
   m_AutoTiling: 0
   m_Points:
     m_Paths:
-    - - {x: -0.40354386, y: 0.35968864}
-      - {x: -0.40495542, y: -0.41885608}
+    - - {x: -0.047144413, y: 0.36496064}
+      - {x: -0.04746481, y: 0.16976057}
+      - {x: -0.2897111, y: 0.16690557}
+      - {x: -0.2891395, y: 0.02836577}
+      - {x: -0.4032071, y: 0.026693594}
+      - {x: -0.40464538, y: -0.24784182}
+      - {x: -0.2900645, y: -0.24717483}
+      - {x: -0.16712469, y: -0.24832365}
+      - {x: -0.16717094, y: -0.2906334}
+      - {x: -0.16832168, y: -0.4162935}
       - {x: 0.36684352, y: -0.4146298}
       - {x: 0.36496136, y: 0.3579981}
   m_UseDelaunayMesh: 0

--- a/GrimsCoffinProject/Assets/Scenes/Noah's Test Scenes/NewTileLevelDesign.unity
+++ b/GrimsCoffinProject/Assets/Scenes/Noah's Test Scenes/NewTileLevelDesign.unity
@@ -1190,6 +1190,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   hasPlayer: 0
+  RoomLive: 0
   Border: {fileID: 857684612}
   VCamera: {fileID: 1036461433}
 --- !u!114 &454498920
@@ -1392,11 +1393,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4894866827985537568, guid: 3901873f192e26840810d12d84daf40c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -15.7
+      value: 66.2
       objectReference: {fileID: 0}
     - target: {fileID: 4894866827985537568, guid: 3901873f192e26840810d12d84daf40c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.1
+      value: 22.2
       objectReference: {fileID: 0}
     - target: {fileID: 4894866827985537568, guid: 3901873f192e26840810d12d84daf40c, type: 3}
       propertyPath: m_LocalPosition.z
@@ -49640,7 +49641,7 @@ Transform:
   m_GameObject: {fileID: 1036461432}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -15.7, y: -2.1, z: -10}
+  m_LocalPosition: {x: 66.2, y: 22.2, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -50180,6 +50181,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   hasPlayer: 1
+  RoomLive: 0
   Border: {fileID: 1971515070}
   VCamera: {fileID: 1036461433}
 --- !u!114 &1150608255
@@ -130124,7 +130126,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 1866543868}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1394500788}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6867ba73de2fb2b429d464b517174d8f, type: 3}
   m_Name: 
@@ -130370,11 +130372,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5158343782362898515, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -14.956107
+      value: 63.307487
       objectReference: {fileID: 0}
     - target: {fileID: 5158343782362898515, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.102415
+      value: 22.187344
       objectReference: {fileID: 0}
     - target: {fileID: 5158343782362898515, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       propertyPath: m_LocalPosition.z
@@ -130430,7 +130432,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5161707832729600314, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7399055257594099030, guid: b5d3d2bccc8e7f14ab67b6542cb539cb, type: 3}
       propertyPath: m_Name

--- a/GrimsCoffinProject/Assets/Scripts/CameraShake.cs
+++ b/GrimsCoffinProject/Assets/Scripts/CameraShake.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Cinemachine;
+
+public class CameraShake : MonoBehaviour
+{
+    public static CameraShake Instance { get; private set; }
+    private CinemachineVirtualCamera Vcam;
+    private float shakeTimer;
+    private void Awake()
+    {
+        Instance = this;
+        Vcam = GetComponent<CinemachineVirtualCamera>();
+    }
+
+    public void ShakeCamera(float intensity, float time) 
+    {
+        CinemachineBasicMultiChannelPerlin cinemachineBasicMultiChannelPerlin=Vcam.GetCinemachineComponent<CinemachineBasicMultiChannelPerlin>();
+        cinemachineBasicMultiChannelPerlin.m_AmplitudeGain = intensity;
+        shakeTimer = time;
+    }
+
+    private void Update()
+    {
+        if (shakeTimer > 0) 
+        {
+        CinemachineBasicMultiChannelPerlin cinemachineBasicMultiChannelPerlin= Vcam.GetCinemachineComponent <CinemachineBasicMultiChannelPerlin>();
+            cinemachineBasicMultiChannelPerlin.m_AmplitudeGain = 0f;
+        }
+    }
+}

--- a/GrimsCoffinProject/Assets/Scripts/CameraShake.cs.meta
+++ b/GrimsCoffinProject/Assets/Scripts/CameraShake.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a8c357984ad0924c8ff769f75ed5732
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GrimsCoffinProject/Assets/Scripts/SceneTransition/Room.cs
+++ b/GrimsCoffinProject/Assets/Scripts/SceneTransition/Room.cs
@@ -1,11 +1,15 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Cinemachine;
 
 public class Room : MonoBehaviour
 {
     [SerializeField]
     private bool hasPlayer;
+    private bool RoomLive;
+    [SerializeField] private GameObject Border;
+    [SerializeField] private CinemachineVirtualCamera VCamera;
 
     // Start is called before the first frame update
     void Start()
@@ -17,6 +21,17 @@ public class Room : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        
+        if (hasPlayer)
+            Changeborder(Border);
+    }
+
+    private void Changeborder(GameObject border)
+    {
+        if (!RoomLive) 
+        {
+            CinemachineConfiner VConfiner = VCamera.GetComponent<CinemachineConfiner>();
+            VConfiner.m_BoundingShape2D = border.GetComponent<PolygonCollider2D>();
+            RoomLive = true;
+        }
     }
 }

--- a/GrimsCoffinProject/Assets/Scripts/SceneTransition/Room.cs
+++ b/GrimsCoffinProject/Assets/Scripts/SceneTransition/Room.cs
@@ -21,7 +21,7 @@ public class Room : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (hasPlayer)
+        if (this.gameObject.activeSelf)
             Changeborder(Border);
     }
 

--- a/GrimsCoffinProject/Assets/Scripts/SceneTransition/Room.cs
+++ b/GrimsCoffinProject/Assets/Scripts/SceneTransition/Room.cs
@@ -7,7 +7,7 @@ public class Room : MonoBehaviour
 {
     [SerializeField]
     private bool hasPlayer;
-    private bool RoomLive;
+    public bool RoomLive;
     [SerializeField] private GameObject Border;
     [SerializeField] private CinemachineVirtualCamera VCamera;
 
@@ -21,17 +21,20 @@ public class Room : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (this.gameObject.activeSelf)
+        if (RoomLive)
+        {
             Changeborder(Border);
+        }
+
     }
 
     private void Changeborder(GameObject border)
     {
-        if (!RoomLive) 
-        {
             CinemachineConfiner VConfiner = VCamera.GetComponent<CinemachineConfiner>();
             VConfiner.m_BoundingShape2D = border.GetComponent<PolygonCollider2D>();
-            RoomLive = true;
-        }
+    }
+    public void SetRoomLiveStatus(bool isActive)
+    {
+        RoomLive = isActive;
     }
 }

--- a/GrimsCoffinProject/Assets/Scripts/SceneTransition/TransitionDoor.cs
+++ b/GrimsCoffinProject/Assets/Scripts/SceneTransition/TransitionDoor.cs
@@ -75,14 +75,14 @@ public class TransitionDoor : MonoBehaviour
         if (!areaEntering.activeInHierarchy)
         {
             areaEntering.SetActive(true);
-            Room Enter = areaEntering.GetComponent<Room>();
-            Enter.RoomLive = true;
             yield return null;
         }
         else
         {
             yield return FadeOut(0.5f);
-            mainCam.SetBorders(roomXMin, roomXMax, roomYMin, roomYMax);
+            Room Enter = areaEntering.GetComponent<Room>();
+            Enter.RoomLive = true;
+            //mainCam.SetBorders(roomXMin, roomXMax, roomYMin, roomYMax);
             col.gameObject.transform.position = outDoor.SpawnPos;
             //yield return new WaitForSeconds(0.5f);
             Color start = new Color(screenFade.color.r, screenFade.color.g, screenFade.color.b, 1f);

--- a/GrimsCoffinProject/Assets/Scripts/SceneTransition/TransitionDoor.cs
+++ b/GrimsCoffinProject/Assets/Scripts/SceneTransition/TransitionDoor.cs
@@ -75,6 +75,8 @@ public class TransitionDoor : MonoBehaviour
         if (!areaEntering.activeInHierarchy)
         {
             areaEntering.SetActive(true);
+            Room Enter = areaEntering.GetComponent<Room>();
+            Enter.RoomLive = true;
             yield return null;
         }
         else
@@ -97,6 +99,8 @@ public class TransitionDoor : MonoBehaviour
         
         yield return Fade(start, target, duration);
         areaExiting.SetActive(false);
+        Room Exit = areaExiting.GetComponent<Room>();
+        Exit.RoomLive = false;
             
     }
     IEnumerator FadeOut(float duration)


### PR DESCRIPTION
<!---
Pull request template for Grim’s Coffin. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
<!--- Can use bullet lists here to cover new additions, but give a bit more detail than what is given in commit messages --->
Add a camera shake script that will trigger camera shake while call the instance of this script.
Change the camera control  from camera follow script to cinemachine so we could introduce cutscene and camera shake
## Please describe how to test
<!---Give the important steps needed for testing your main changes--->

1. Open Noah's Scene and the open Newtilelevel design
2. Play through the level to see the camera transition
**3.** There is no current function that trigger the camera shake but it have a instance. If you wanna plug that function in anywhere just type"CameraShake.Instance.ShakeCamera(float,float)". It will add the camera shake and then decrease the ratio through time. the first float control how heave it shake and the second one is the duration. I recommend start at 1,1

## Relevant Screenshots
<!---Paste in some screenshots to help reduce the need for excess testing. If screenshots are not relevant here, then remove this section--->

## Issue worked on
<!---Paste in a link to the issue this PR addresses--->
https://emotional-baggage.atlassian.net/jira/software/projects/GRIM/boards/1?selectedIssue=GRIM-58
## Link to Feature Devlog
<!---Paste in a link to the devlog documentation for this feature--->
https://docs.google.com/document/d/1egmKNRr22Z0ZzfbkUs12ifGFyx3dQdSPJI8TlDREjQE/edit?tab=t.0#heading=h.ivx1gx60e48z
## What Sprint is this due in?
<!---Only need to indicate here which week/deliverable the PR is for--->
2