### PR TITLE
Minor Post Playtest 2 Updates

### DIFF
--- a/GrimsCoffinProject/Assets/Input/PlayerControls.cs
+++ b/GrimsCoffinProject/Assets/Input/PlayerControls.cs
@@ -217,6 +217,17 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                 },
                 {
                     ""name"": """",
+                    ""id"": ""56289f13-d22d-4666-8ac4-fb0f854462f5"",
+                    ""path"": ""<Gamepad>/dpad"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Gamepad;Playstation;Xbox"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
                     ""id"": ""bf588a28-ca1d-4107-b21b-7eff0a95f012"",
                     ""path"": ""<Keyboard>/space"",
                     ""interactions"": """",

--- a/GrimsCoffinProject/Assets/Input/PlayerControls.inputactions
+++ b/GrimsCoffinProject/Assets/Input/PlayerControls.inputactions
@@ -195,6 +195,17 @@
                 },
                 {
                     "name": "",
+                    "id": "56289f13-d22d-4666-8ac4-fb0f854462f5",
+                    "path": "<Gamepad>/dpad",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad;Playstation;Xbox",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
                     "id": "bf588a28-ca1d-4107-b21b-7eff0a95f012",
                     "path": "<Keyboard>/space",
                     "interactions": "",

--- a/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/PauseScreen.prefab
+++ b/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/PauseScreen.prefab
@@ -801,6 +801,14 @@ PrefabInstance:
       value: Quit
       objectReference: {fileID: 0}
     - target: {fileID: 8005780420589934167, guid: 62d28414c413c2a46a8b3d4e69157c75, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8005780420589934167, guid: 62d28414c413c2a46a8b3d4e69157c75, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 2524003961777760642}
+    - target: {fileID: 8005780420589934167, guid: 62d28414c413c2a46a8b3d4e69157c75, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 8640537482224829310}
@@ -966,6 +974,18 @@ PrefabInstance:
       value: Controls
       objectReference: {fileID: 0}
     - target: {fileID: 8005780420589934167, guid: 62d28414c413c2a46a8b3d4e69157c75, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8005780420589934167, guid: 62d28414c413c2a46a8b3d4e69157c75, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 2392151391988972910}
+    - target: {fileID: 8005780420589934167, guid: 62d28414c413c2a46a8b3d4e69157c75, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 5278448178787752966}
+    - target: {fileID: 8005780420589934167, guid: 62d28414c413c2a46a8b3d4e69157c75, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 8640537482224829310}
@@ -982,6 +1002,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 62d28414c413c2a46a8b3d4e69157c75, type: 3}
+--- !u!114 &2524003961777760642 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8005780420589934167, guid: 62d28414c413c2a46a8b3d4e69157c75, type: 3}
+  m_PrefabInstance: {fileID: 5484591440522346453}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &7486735051049135231 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3169152083954013098, guid: 62d28414c413c2a46a8b3d4e69157c75, type: 3}
@@ -1119,6 +1150,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: Resume
       objectReference: {fileID: 0}
+    - target: {fileID: 8005780420589934167, guid: 62d28414c413c2a46a8b3d4e69157c75, type: 3}
+      propertyPath: m_Navigation.m_Mode
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8005780420589934167, guid: 62d28414c413c2a46a8b3d4e69157c75, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 2524003961777760642}
     - target: {fileID: 8005780420589934167, guid: 62d28414c413c2a46a8b3d4e69157c75, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 

--- a/GrimsCoffinProject/Assets/Scripts/Enemies/Enemy.cs
+++ b/GrimsCoffinProject/Assets/Scripts/Enemies/Enemy.cs
@@ -47,7 +47,7 @@ public abstract class Enemy : MonoBehaviour
     public virtual void TakeDamage(float damage = 1)
     {
         health -= damage;
-        CameraShake.Instance.ShakeCamera(4, 3, .2f);
+        CameraShake.Instance.ShakeCamera(2.5f, 1.75f, .2f);
 
         if (health <= 0)
             DestroyEnemy();


### PR DESCRIPTION
## Summarize what is being added
-Reduced intensity of camera shake when damaging enemies.
-Fixed Navigation of Quit button on Pause Screen
-Added Input Mapping for D-Pad, allowing it to be used for Movement & Menu Navigation

## Please describe how to test
-Open the NewTileLevelDesign scene and play it, go into the next room (make sure you can move with the D-Pad) and damage enemies. How does the camera shake feel?
-Pause the game and navigate the menu using the D-Pad. Moving up when selecting the Quit button should select Controls (It previously would select Resume)

## Issue worked on
No issue

## Link to Feature Devlog
No devlog, minor tweaks and bug fixes

## What Sprint is this due in?
Sprint 3