### PR TITLE
Spirit Progression

### DIFF
--- a/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/SaveIcon.prefab
+++ b/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/SaveIcon.prefab
@@ -18,7 +18,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &7987709186401433609
 RectTransform:
   m_ObjectHideFlags: 0

--- a/GrimsCoffinProject/Assets/Scenes/Kevin's Test Scenes/DenialMinimap.unity
+++ b/GrimsCoffinProject/Assets/Scenes/Kevin's Test Scenes/DenialMinimap.unity
@@ -12354,13 +12354,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   pauseScript: {fileID: 328030540}
-  restPointMenu: {fileID: 0}
+  restPointMenu: {fileID: 1965619422}
   deathScreen: {fileID: 2106832685}
   lowHealthVignette: {fileID: 1668986490}
   damageVignette: {fileID: 1800529130}
   gameUI: {fileID: 1364930436}
-  areaText: {fileID: 0}
-  saveIcon: {fileID: 0}
+  areaText: {fileID: 1449641910}
+  saveIcon: {fileID: 720728039}
+  minimapUI: {fileID: 1729912099}
   fullMapUI: {fileID: 717339525}
   mapRooms:
   - {fileID: 1920715330}
@@ -12444,7 +12445,68 @@ MonoBehaviour:
   defaultXPos: -16
   defaultYPos: -1.7
   defaultSceneName: NewGame
-  defaultHP: 125
+  defaultHP: 50
+--- !u!1001 &318357344
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 57972593741740195, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_Name
+      value: SpiritSpawnPoint (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27.963718
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.5036793
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787397257723873366, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: spiritID
+      value: 4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
 --- !u!1001 &318745613
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12660,7 +12722,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7084655446754543120, guid: de664976753e3124f9024b5d608c9aa1, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 3.8599854
+      value: 3.8598633
       objectReference: {fileID: 0}
     - target: {fileID: 7084655446754543120, guid: de664976753e3124f9024b5d608c9aa1, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -22182,6 +22244,67 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!1001 &593443207
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3412099861116279620, guid: 6fd149cb3d2ff584f9c28090d0bde128, type: 3}
+      propertyPath: roomIndex
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3571654701704625484, guid: 6fd149cb3d2ff584f9c28090d0bde128, type: 3}
+      propertyPath: m_Name
+      value: Save Point
+      objectReference: {fileID: 0}
+    - target: {fileID: 7950690345586759872, guid: 6fd149cb3d2ff584f9c28090d0bde128, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 36.386787
+      objectReference: {fileID: 0}
+    - target: {fileID: 7950690345586759872, guid: 6fd149cb3d2ff584f9c28090d0bde128, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.030177116
+      objectReference: {fileID: 0}
+    - target: {fileID: 7950690345586759872, guid: 6fd149cb3d2ff584f9c28090d0bde128, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7950690345586759872, guid: 6fd149cb3d2ff584f9c28090d0bde128, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7950690345586759872, guid: 6fd149cb3d2ff584f9c28090d0bde128, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7950690345586759872, guid: 6fd149cb3d2ff584f9c28090d0bde128, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7950690345586759872, guid: 6fd149cb3d2ff584f9c28090d0bde128, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7950690345586759872, guid: 6fd149cb3d2ff584f9c28090d0bde128, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7950690345586759872, guid: 6fd149cb3d2ff584f9c28090d0bde128, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7950690345586759872, guid: 6fd149cb3d2ff584f9c28090d0bde128, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6fd149cb3d2ff584f9c28090d0bde128, type: 3}
 --- !u!1001 &620781409
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -22548,6 +22671,11 @@ Grid:
 GameObject:
   m_CorrespondingSourceObject: {fileID: 980002342337866902, guid: 698fadeb5dc3df9498e7d1d428929c08, type: 3}
   m_PrefabInstance: {fileID: 1198510210}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &720728039 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8374010533625897418, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+  m_PrefabInstance: {fileID: 877545622}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &763526493
 GameObject:
@@ -24846,6 +24974,67 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!1001 &795366871
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 57972593741740195, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_Name
+      value: SpiritSpawnPoint (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.24406
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.6816311
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787397257723873366, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: spiritID
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
 --- !u!1001 &805187308
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -25285,6 +25474,169 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ca3486bfb9e2c6147a2b08c49c6de295, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &874266070
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 57972593741740195, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_Name
+      value: SpiritSpawnPoint (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22.684471
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.5036793
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787397257723873366, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: spiritID
+      value: 3
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+--- !u!1001 &877545622
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1141389180}
+    m_Modifications:
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 831
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -429
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8374010533625897418, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+      propertyPath: m_Name
+      value: SaveIcon
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+--- !u!224 &877545623 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7987709186401433609, guid: a53d74e1a5070864b98ce3ab8093b52e, type: 3}
+  m_PrefabInstance: {fileID: 877545622}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &924246410
 GameObject:
   m_ObjectHideFlags: 0
@@ -31830,6 +32182,8 @@ RectTransform:
   - {fileID: 2081727856}
   - {fileID: 1198510211}
   - {fileID: 1205697587}
+  - {fileID: 877545623}
+  - {fileID: 1965619421}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -37317,6 +37671,11 @@ Transform:
   - {fileID: 1205013410}
   m_Father: {fileID: 1580348510}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1449641910 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1994732691585857305, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
+  m_PrefabInstance: {fileID: 2081727855}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1535482307
 GameObject:
   m_ObjectHideFlags: 0
@@ -46639,6 +46998,11 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 2677444878165488555, guid: ee868d3bfc7eade4a82d37fb2e9fe2c7, type: 3}
   m_PrefabInstance: {fileID: 1728201465}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1729912099 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 781126446651267695, guid: 3bb0924a043e3d548b84309c8a4d2aa0, type: 3}
+  m_PrefabInstance: {fileID: 2089551497}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1760524050
 GameObject:
@@ -70393,6 +70757,119 @@ Transform:
   - {fileID: 1274033823}
   m_Father: {fileID: 1580348510}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1965619420
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1141389180}
+    m_Modifications:
+    - target: {fileID: 2284561043177218150, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_Name
+      value: RestPointMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -1594.6329
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: -660.5261
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 311
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 102
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+--- !u!224 &1965619421 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4239926424229030139, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+  m_PrefabInstance: {fileID: 1965619420}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1965619422 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7082746443859745713, guid: a6a97c91b4bfced438b196539a3c9e1b, type: 3}
+  m_PrefabInstance: {fileID: 1965619420}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03b7119aeb10e0946be0addba63b6b5d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2006691589
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -70928,6 +71405,67 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 691074518195588859, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
   m_PrefabInstance: {fileID: 2081727855}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2088930248
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 57972593741740195, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_Name
+      value: SpiritSpawnPoint
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 14.676622
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.5629964
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 856169698987487715, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787397257723873366, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
+      propertyPath: spiritID
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f4a004e00ab730d439117e2833d9d6ea, type: 3}
 --- !u!1001 &2089551497
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -70939,6 +71477,10 @@ PrefabInstance:
     - target: {fileID: 781126446651267695, guid: 3bb0924a043e3d548b84309c8a4d2aa0, type: 3}
       propertyPath: m_Name
       value: Minimap Panel
+      objectReference: {fileID: 0}
+    - target: {fileID: 781126446651267695, guid: 3bb0924a043e3d548b84309c8a4d2aa0, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5652564619555494922, guid: 3bb0924a043e3d548b84309c8a4d2aa0, type: 3}
       propertyPath: m_Pivot.x
@@ -71713,3 +72255,8 @@ SceneRoots:
   - {fileID: 2034934076}
   - {fileID: 1671632356}
   - {fileID: 1920715314}
+  - {fileID: 593443207}
+  - {fileID: 2088930248}
+  - {fileID: 795366871}
+  - {fileID: 874266070}
+  - {fileID: 318357344}

--- a/GrimsCoffinProject/Assets/Scenes/Kevin's Test Scenes/Equilibrium.unity
+++ b/GrimsCoffinProject/Assets/Scenes/Kevin's Test Scenes/Equilibrium.unity
@@ -811,7 +811,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1960859601187753200, guid: 3901873f192e26840810d12d84daf40c, type: 3}
       propertyPath: currentHP
-      value: 50
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 4894866827985537568, guid: 3901873f192e26840810d12d84daf40c, type: 3}
       propertyPath: m_LocalPosition.x
@@ -23764,10 +23764,12 @@ MonoBehaviour:
   gameUI: {fileID: 1863953469}
   areaText: {fileID: 8183291775625397402}
   saveIcon: {fileID: 0}
+  minimapUI: {fileID: 0}
   fullMapUI: {fileID: 0}
   mapRooms: []
   dialogueUI: {fileID: 952499286}
   playerInput: {fileID: 584877822}
+  scytheThrowInMenu: 0
 --- !u!4 &2117058707
 Transform:
   m_ObjectHideFlags: 0
@@ -23815,7 +23817,7 @@ MonoBehaviour:
   defaultXPos: -11.08
   defaultYPos: -2.85
   defaultSceneName: OnboardingLevel
-  defaultHP: 125
+  defaultHP: 50
 --- !u!114 &2117058710
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/GrimsCoffinProject/Assets/Scriptable Objects/PlayerMovementDataV.2.asset
+++ b/GrimsCoffinProject/Assets/Scriptable Objects/PlayerMovementDataV.2.asset
@@ -17,8 +17,8 @@ MonoBehaviour:
   cameraOffset: 0.6
   cameraWalkOffset: -0.1
   cameraDashOffset: -0.15
-  maxHP: 125
-  maxSP: 0
+  maxHP: 50
+  maxSP: 50
   respawnPoint: {x: 0, y: 0}
   gravityStrength: -57.14286
   gravityScale: 5.82496
@@ -52,7 +52,7 @@ MonoBehaviour:
   wallCoyoteTime: 0.01
   doTurnOnWallJump: 1
   wallTurnBuffer: 0
-  canDoubleJump: 1
+  canDoubleJump: 0
   preserveDoubleJump: 1
   resetJumpOnWall: 0
   extraJumpMultiplier: 0
@@ -109,3 +109,4 @@ MonoBehaviour:
   aerialDownDamage: 7
   aerialImpactDamage: 5
   canScytheThrow: 1
+  canViewMap: 1

--- a/GrimsCoffinProject/Assets/Scripts/PersistentDataManager.cs
+++ b/GrimsCoffinProject/Assets/Scripts/PersistentDataManager.cs
@@ -30,6 +30,8 @@ public class PersistentDataManager : MonoBehaviour
     public bool CanDoubleJump { get { return PlayerPrefs.GetInt("CanDoubleJump", 0) == 1; } }
     public bool CanDash { get { return PlayerPrefs.GetInt("CanDash", 0) == 1; } }
     public bool CanWallJump { get { return PlayerPrefs.GetInt("CanWallJump", 0) == 1; } }
+    public bool CanScytheThrow { get { return PlayerPrefs.GetInt("CanScytheThrow", 0) == 1; } }
+    public bool CanViewMap { get { return PlayerPrefs.GetInt("CanViewMap", 0) == 1; } }
 
     //Whether or not the Player is entering the Denial Area Scene for the first time
     public bool FirstTimeInDenial { get { return PlayerPrefs.GetInt("FirstTimeDenial", 1) == 1; } }
@@ -95,9 +97,45 @@ public class PersistentDataManager : MonoBehaviour
 
             //Show save icon when spirit is collected
             if (spirit.spiritState == Spirit.SpiritState.Collected)
+            {
                 StartCoroutine(UIManager.Instance.ShowSaveIcon(2));
-        }
+            }
 
+            //Spirit Ability Unlocks
+            else if (spirit.spiritState == Spirit.SpiritState.Idle)
+            {
+                switch (spirit.spiritID)
+                {
+                    //Unlocks Minimap and Map access
+                    case Spirit.SpiritID.MapSpirit:
+                        PlayerPrefs.SetInt("CanViewMap", 1);
+                        break;
+
+                    //Unlocks Dash
+                    case Spirit.SpiritID.DashSpirit:
+                        PlayerControllerForces.Instance.Data.canDash = true;
+                        PlayerPrefs.SetInt("CanDash", 1);
+                        break;
+
+                    //Unlocks Scythe Throw and Spirit Power
+                    case Spirit.SpiritID.ScytheThrowSpirit:
+                        PlayerControllerForces.Instance.Data.canScytheThrow = true;
+                        PlayerControllerForces.Instance.Data.maxSP = 50;
+                        PlayerControllerForces.Instance.currentSP = PlayerControllerForces.Instance.Data.maxSP;
+                        PlayerPrefs.SetInt("CanScytheThrow", 1);
+                        PlayerPrefs.SetFloat("MaxSP", 50);
+                        break;
+
+                    //Unlocks Health Upgrades and gives one for free
+                    case Spirit.SpiritID.HealthSpirit:
+                        PlayerControllerForces.Instance.Data.maxHP += 15;
+                        PlayerControllerForces.Instance.currentHP = PlayerControllerForces.Instance.Data.maxHP; 
+                        PlayerPrefs.SetFloat("MaxHP", PlayerControllerForces.Instance.Data.maxHP);
+                        break;
+                }
+            }
+                
+        }
         PlayerPrefs.SetString(spirit.spiritID.ToString(), spirit.spiritState.ToString());
     }
 
@@ -166,9 +204,10 @@ public class PersistentDataManager : MonoBehaviour
         PlayerPrefs.SetInt("CanDash", 0);
 
         //Reset Spirit Data
-        PlayerPrefs.SetString("Spirit1", "Uncollected");
-        PlayerPrefs.SetString("Spirit2", "Uncollected");
-        PlayerPrefs.SetString("Spirit3", "Uncollected");
+        PlayerPrefs.SetString("MapSpirit", "Uncollected");
+        PlayerPrefs.SetString("DashSpirit", "Uncollected");
+        PlayerPrefs.SetString("ScytheThrowSpirit", "Uncollected");
+        PlayerPrefs.SetString("HealthSpirit", "Uncollected");
 
         //Clear Onboarding Map Data
         for (int i = 0; i < 20; i++)

--- a/GrimsCoffinProject/Assets/Scripts/Player/PlayerControllerForces.cs
+++ b/GrimsCoffinProject/Assets/Scripts/Player/PlayerControllerForces.cs
@@ -151,6 +151,8 @@ public class PlayerControllerForces : MonoBehaviour
         Data.canDoubleJump = PersistentDataManager.Instance.CanDoubleJump;
         Data.canWallJump = PersistentDataManager.Instance.CanWallJump;
         Data.canDash = PersistentDataManager.Instance.CanDash;
+        Data.canScytheThrow = PersistentDataManager.Instance.CanScytheThrow;
+        Data.canViewMap = PersistentDataManager.Instance.CanViewMap;
 
         LastJumpTime = 0;
         LastWallJumpTime = 0;

--- a/GrimsCoffinProject/Assets/Scripts/Player/PlayerData.cs
+++ b/GrimsCoffinProject/Assets/Scripts/Player/PlayerData.cs
@@ -196,10 +196,16 @@ public class PlayerData : ScriptableObject
     public float aerialDownDamage;
     public float aerialImpactDamage;
 
-    [Space(20)]
+    [Space(15)]
 
     [Header("Scythe Throw")]
     public bool canScytheThrow;
+
+    [Space(20)]
+
+    [Header("Map")]
+    public bool canViewMap;
+
 
     //Unity Callback, called when the inspector updates
     private void OnValidate()

--- a/GrimsCoffinProject/Assets/Scripts/Spirit.cs
+++ b/GrimsCoffinProject/Assets/Scripts/Spirit.cs
@@ -12,10 +12,10 @@ public class Spirit : Interactable
 
     public enum SpiritID
     {
-        Spirit1 = 1,
-        Spirit2 = 2,
-        Spirit3 = 3,
-        Spirit4 = 4,
+        MapSpirit = 1,
+        DashSpirit = 2,
+        ScytheThrowSpirit = 3,
+        HealthSpirit = 4,
     }
 
     [SerializeField] public SpiritState spiritState;
@@ -43,7 +43,8 @@ public class Spirit : Interactable
 
     public override void PerformInteraction()
     {
-        dialogueManager.ShowDialogueForSpirit(spiritID, spiritState);
+        if (dialogueManager != null) 
+            dialogueManager.ShowDialogueForSpirit(spiritID, spiritState);
 
         if (spiritState == SpiritState.Uncollected)
         {

--- a/GrimsCoffinProject/Assets/Scripts/UI Scripts/RestPointMenu.cs
+++ b/GrimsCoffinProject/Assets/Scripts/UI Scripts/RestPointMenu.cs
@@ -32,7 +32,7 @@ public class RestPointMenu: MonoBehaviour
 
         else
         {
-            SceneManager.LoadScene(3);
+            SceneManager.LoadScene("Equilibrium");
         }
     }
 
@@ -58,6 +58,7 @@ public class RestPointMenu: MonoBehaviour
 
         else if (this.gameObject.activeInHierarchy && insideEquilibrium)
         {
+            Heal();
             outsideEQPanel.SetActive(false);
             insideEQPanel.SetActive(true);
 
@@ -84,5 +85,6 @@ public class RestPointMenu: MonoBehaviour
     public void Heal()
     {
         PlayerControllerForces.Instance.currentHP = PlayerControllerForces.Instance.Data.maxHP;
+        PlayerControllerForces.Instance.currentSP = PlayerControllerForces.Instance.Data.maxSP;
     }
 }

--- a/GrimsCoffinProject/Assets/Scripts/UI Scripts/UIManager.cs
+++ b/GrimsCoffinProject/Assets/Scripts/UI Scripts/UIManager.cs
@@ -20,6 +20,7 @@ public class UIManager : MonoBehaviour
     [SerializeField] public GameObject areaText;
     [SerializeField] private GameObject saveIcon;
 
+    [SerializeField] private GameObject minimapUI;
     [SerializeField] private GameObject fullMapUI;
     [SerializeField] private List<GameObject> mapRooms;
     [SerializeField] public GameObject dialogueUI;
@@ -43,6 +44,9 @@ public class UIManager : MonoBehaviour
 
     private void Update()
     {
+        if (PlayerControllerForces.Instance.Data.canViewMap && minimapUI != null)
+            minimapUI.SetActive(true);
+
         if (damageVignette == null || !damageVignette.gameObject.activeInHierarchy)
             return;
 
@@ -85,6 +89,9 @@ public class UIManager : MonoBehaviour
 
     public void ToggleMap()
     {
+        if (!PlayerControllerForces.Instance.Data.canViewMap)
+            return;
+
         bool mapActive = !fullMapUI.activeInHierarchy;
 
         gameUI.SetActive(!mapActive);
@@ -129,7 +136,7 @@ public class UIManager : MonoBehaviour
             for (int i = 0; i < roomsExplored.Count; i++)
             {
                 {
-                    if (roomsExplored[i])
+                    if (roomsExplored[i] && mapRooms.Count > 0)
                         mapRooms[i].SetActive(true);
                 }
             }

--- a/GrimsCoffinProject/ProjectSettings/EditorBuildSettings.asset
+++ b/GrimsCoffinProject/ProjectSettings/EditorBuildSettings.asset
@@ -14,7 +14,7 @@ EditorBuildSettings:
   - enabled: 0
     path: Assets/Scenes/GameScenes/OnboardingLevel.unity
     guid: c4be95d6492bd4542ae3a04e20566a10
-  - enabled: 0
+  - enabled: 1
     path: Assets/Scenes/Kevin's Test Scenes/Equilibrium.unity
     guid: 41da7c7ae83f16e4c9bb097671499de5
   - enabled: 0


### PR DESCRIPTION
## Summarize what is being added
-Spirits now provide progression and unlock certain abilities/mechanics in the game
-4 Spirits added to test unlocking Map, Dash, Scythe Throw, and Health Upgrades

## Please describe how to test
-Open the build and click new game, there should be 4 spirits in front of you and a rest point
-The order of the spirits is Map, Dash, Scythe Throw, and Health Upgrade
-Collect one spirit at a time, then interact with them in Equilibrium
-Interacting with them in Equilibrium will unlock their respective unlock (You need to go back to The Drift to notice the map unlock)
-Once a spirit has been interacted with and their ability unlocked, it should persist when you return to the drift
-Health spirit gives just one free health upgrade now, with the system for getting more to be implemented later

## Issue worked on
https://emotional-baggage.atlassian.net/jira/software/projects/GRIM/boards/1?selectedIssue=GRIM-111

## Link to Build
https://drive.google.com/file/d/1FVojyArxZS9q_S7aZVoUAlp5Gt9GhFlD/view?usp=sharing

## Link to Documentation
https://docs.google.com/document/d/1iZb2SRyBWoKc3UYMsVdhkGbx9wkAkkQ6/edit#heading=h.5n5mnw01iq9

## What Sprint is this due in?
Sprint 5