### PR TITLE
Feature/enemy drops

### DIFF
--- a/GrimsCoffinProject/Assets/Font/joystix monospace SDF.asset
+++ b/GrimsCoffinProject/Assets/Font/joystix monospace SDF.asset
@@ -2109,7 +2109,8 @@ Material:
   m_Shader: {fileID: 4800000, guid: 68e6db2ebdc24f95958faec2be5558d6, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
+  m_ValidKeywords:
+  - UNDERLAY_ON
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -2168,12 +2169,12 @@ Material:
     - _OutlineSoftness: 0
     - _OutlineUVSpeedX: 0
     - _OutlineUVSpeedY: 0
-    - _OutlineWidth: 0
+    - _OutlineWidth: 0.15
     - _PerspectiveFilter: 0.875
     - _Reflectivity: 10
     - _ScaleRatioA: 0.8333333
     - _ScaleRatioB: 0.6770833
-    - _ScaleRatioC: 0.6770833
+    - _ScaleRatioC: 0.33854166
     - _ScaleX: 1
     - _ScaleY: 1
     - _ShaderFlags: 0
@@ -2186,9 +2187,9 @@ Material:
     - _StencilWriteMask: 255
     - _TextureHeight: 512
     - _TextureWidth: 512
-    - _UnderlayDilate: 0
-    - _UnderlayOffsetX: 0
-    - _UnderlayOffsetY: 0
+    - _UnderlayDilate: 1
+    - _UnderlayOffsetX: 1
+    - _UnderlayOffsetY: -1
     - _UnderlaySoftness: 0
     - _VertexOffsetX: 0
     - _VertexOffsetY: 0
@@ -2204,5 +2205,5 @@ Material:
     - _ReflectFaceColor: {r: 0, g: 0, b: 0, a: 1}
     - _ReflectOutlineColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
-    - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
+    - _UnderlayColor: {r: 0, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []

--- a/GrimsCoffinProject/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
+++ b/GrimsCoffinProject/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
@@ -712,7 +712,7 @@ MonoBehaviour:
   - {fileID: 7835905458541246840}
   StringsBanks:
   - {fileID: 1212590281995229497}
-  cacheTime: 638744493654914480
+  cacheTime: 638749642545749024
   cacheVersion: 131620
 --- !u!114 &428993134770705617
 MonoBehaviour:
@@ -838,7 +838,7 @@ MonoBehaviour:
   Path: Assets/FMOD/Bank/Desktop/Master.strings.bank
   Name: Master.strings
   StudioPath: bank:/Master.strings
-  lastModified: 638744493654914480
+  lastModified: 638749642545749024
   FileSizes:
   - Name: Desktop
     Value: 3230
@@ -1254,7 +1254,7 @@ MonoBehaviour:
   Path: Assets/FMOD/Bank/Desktop/Master.bank
   Name: Master
   StudioPath: bank:/Master
-  lastModified: 638744493654904506
+  lastModified: 638749642545749024
   FileSizes:
   - Name: Desktop
     Value: 41492800

--- a/GrimsCoffinProject/Assets/Prefabs/Enemies/Basic Skeleton.prefab
+++ b/GrimsCoffinProject/Assets/Prefabs/Enemies/Basic Skeleton.prefab
@@ -680,6 +680,7 @@ MonoBehaviour:
   enemyGFX: {fileID: 7666600489444073033}
   enemy: {fileID: 4567458006229910762}
   playerTarget: {fileID: 0}
+  enemyDropPrefab: {fileID: 5018094658481689379, guid: 83422a90486a2434b9558bea87306358, type: 3}
   groundLayer:
     serializedVersion: 2
     m_Bits: 8

--- a/GrimsCoffinProject/Assets/Prefabs/Enemies/EnemiesV1/FlyingEnemy.prefab
+++ b/GrimsCoffinProject/Assets/Prefabs/Enemies/EnemiesV1/FlyingEnemy.prefab
@@ -403,6 +403,7 @@ MonoBehaviour:
   health: 15
   damage: 10
   movementSpeed: 500
+  seekSpeed: 0
   visionRange: 10
   knockbackMult: 1
   hitbox: {fileID: 0}
@@ -410,6 +411,7 @@ MonoBehaviour:
   enemyGFX: {fileID: 2698454589458360526}
   enemy: {fileID: 7044810579388639336}
   playerTarget: {fileID: 0}
+  enemyDropPrefab: {fileID: 5018094658481689379, guid: 83422a90486a2434b9558bea87306358, type: 3}
   groundLayer:
     serializedVersion: 2
     m_Bits: 8

--- a/GrimsCoffinProject/Assets/Prefabs/Enemies/Enemy Drops.meta
+++ b/GrimsCoffinProject/Assets/Prefabs/Enemies/Enemy Drops.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bcfb22073c34ea2459afb0736a3ca1b3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GrimsCoffinProject/Assets/Prefabs/Enemies/Enemy Drops/Enemy Drop.prefab
+++ b/GrimsCoffinProject/Assets/Prefabs/Enemies/Enemy Drops/Enemy Drop.prefab
@@ -1,0 +1,140 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5018094658481689379
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8638745306620307969}
+  - component: {fileID: 4684179120831987743}
+  - component: {fileID: 8556669626866136541}
+  - component: {fileID: 5268176325780586955}
+  m_Layer: 0
+  m_Name: Enemy Drop
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8638745306620307969
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5018094658481689379}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -12.713, y: 0.166, z: 0}
+  m_LocalScale: {x: 0.6, y: 0.6, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &4684179120831987743
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5018094658481689379}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.9411765}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &8556669626866136541
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5018094658481689379}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 2
+--- !u!114 &5268176325780586955
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5018094658481689379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a3cdfac1af519d4a94cdc77f6922a4b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healthColor: {r: 1, g: 0, b: 0, a: 0.9411765}
+  spiritPowerColor: {r: 0.61960787, g: 0.9372549, b: 0.94509804, a: 0.9411765}
+  dropType: 0
+  speed: 10
+  value: 10

--- a/GrimsCoffinProject/Assets/Prefabs/Enemies/Enemy Drops/Enemy Drop.prefab.meta
+++ b/GrimsCoffinProject/Assets/Prefabs/Enemies/Enemy Drops/Enemy Drop.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 83422a90486a2434b9558bea87306358
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/Area Text.prefab
+++ b/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/Area Text.prefab
@@ -169,4 +169,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5de98b83e328afc4b8208f44ad16003f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  areaName: 

--- a/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/FullMapScreen.prefab
+++ b/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/FullMapScreen.prefab
@@ -673,13 +673,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -1017,13 +1017,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -3147,13 +3147,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -3907,13 +3907,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -4041,13 +4041,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -4459,13 +4459,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -4745,13 +4745,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0

--- a/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/FullMapScreen.prefab
+++ b/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/FullMapScreen.prefab
@@ -405,13 +405,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -539,13 +539,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -883,13 +883,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -1345,13 +1345,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -1479,13 +1479,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -1689,13 +1689,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -1940,13 +1940,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -2074,13 +2074,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -2208,13 +2208,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -2778,13 +2778,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -3564,13 +3564,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
@@ -4249,13 +4249,13 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
+  m_enableVertexGradient: 1
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
+    bottomRight: {r: 0.5176471, g: 0.5176471, b: 0.5176471, a: 1}
   m_fontColorGradientPreset: {fileID: 0}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0

--- a/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/Interaction Prompt.prefab
+++ b/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/Interaction Prompt.prefab
@@ -311,8 +311,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 71.17157, y: -0.000022411}
-  m_SizeDelta: {x: 335.6129, y: 91.4107}
+  m_AnchoredPosition: {x: 210, y: -0.0000052452}
+  m_SizeDelta: {x: 623.4032, y: 93.124}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7691491495901324179
 CanvasRenderer:
@@ -354,7 +354,7 @@ MonoBehaviour:
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 1
-  m_colorMode: 0
+  m_colorMode: 2
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
@@ -369,7 +369,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36.85
+  m_fontSize: 68.45
   m_fontSizeBase: 45.1
   m_fontWeight: 400
   m_enableAutoSizing: 1

--- a/GrimsCoffinProject/Assets/Scenes/Boxi's Test Scene/Scene Transition Cutscene.unity
+++ b/GrimsCoffinProject/Assets/Scenes/Boxi's Test Scene/Scene Transition Cutscene.unity
@@ -317,6 +317,13 @@ MonoBehaviour:
   - {fileID: 21300000, guid: 4c842d9c0dae8724eaa0f9ea89a59534, type: 3}
   continuePrompt: {fileID: 1214632594}
   skipPrompt: {fileID: 1527651054}
+  EventReference:
+    Guid:
+      Data1: 0
+      Data2: 0
+      Data3: 0
+      Data4: 0
+    Path: 
 --- !u!4 &164312467
 Transform:
   m_ObjectHideFlags: 0
@@ -344,7 +351,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d4626a2fdd0355247a2bbbfe50b41ffe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  nextSceneName: ArenaPlaytestLevel2
+  nextSceneName: Lighting_Test
 --- !u!114 &164312469
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/GrimsCoffinProject/Assets/Scenes/Kevin's Test Scenes/Equilibrium.unity
+++ b/GrimsCoffinProject/Assets/Scenes/Kevin's Test Scenes/Equilibrium.unity
@@ -968,6 +968,14 @@ PrefabInstance:
       propertyPath: m_FlipX
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8170750240961343010, guid: 3901873f192e26840810d12d84daf40c, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 289
+      objectReference: {fileID: 0}
+    - target: {fileID: 8170750240961343010, guid: 3901873f192e26840810d12d84daf40c, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -23961,6 +23969,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   pauseScript: {fileID: 113711802}
   restPointMenu: {fileID: 1116646275}
+  mapScript: {fileID: 0}
   deathScreen: {fileID: 71615578}
   lowHealthVignette: {fileID: 1669771902}
   damageVignette: {fileID: 1772996436}
@@ -23970,6 +23979,8 @@ MonoBehaviour:
   minimapUI: {fileID: 0}
   fullMapUI: {fileID: 0}
   mapRooms: []
+  mapPromptIcons: []
+  mapPrompt: {fileID: 0}
   dialogueUI: {fileID: 952499286}
   playerInput: {fileID: 584877822}
   scytheThrowInMenu: 0

--- a/GrimsCoffinProject/Assets/Scenes/Kevin's Test Scenes/Equilibrium.unity
+++ b/GrimsCoffinProject/Assets/Scenes/Kevin's Test Scenes/Equilibrium.unity
@@ -24329,19 +24329,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColor.b
-      value: 0.3567996
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColor.g
-      value: 0.3567996
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColor.r
-      value: 0.3584906
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColor32.rgba
-      value: 4284177243
+      value: 4294967295
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.topLeft.a
@@ -24349,15 +24349,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.topLeft.b
-      value: 0.5176471
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.topLeft.g
-      value: 0.5176471
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.topLeft.r
-      value: 0.5176471
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.topRight.a
@@ -24365,39 +24365,39 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.topRight.b
-      value: 0.5176471
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.topRight.g
-      value: 0.5176471
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.topRight.r
-      value: 0.5176471
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.bottomLeft.b
-      value: 1
+      value: 0.5176471
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.bottomLeft.g
-      value: 1
+      value: 0.5176471
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.bottomLeft.r
-      value: 1
+      value: 0.5176471
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.bottomRight.b
-      value: 1
+      value: 0.5176471
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.bottomRight.g
-      value: 1
+      value: 0.5176471
       objectReference: {fileID: 0}
     - target: {fileID: 7544504829230695504, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: m_fontColorGradient.bottomRight.r
-      value: 1
+      value: 0.5176471
       objectReference: {fileID: 0}
     - target: {fileID: 9010041153843542453, guid: 23aab86635497ef46bac870ab152edfa, type: 3}
       propertyPath: areaName

--- a/GrimsCoffinProject/Assets/Scripts/Enemies/Enemy.cs
+++ b/GrimsCoffinProject/Assets/Scripts/Enemies/Enemy.cs
@@ -22,6 +22,7 @@ public abstract class Enemy : MonoBehaviour
     [SerializeField] protected GameObject enemy;
     [SerializeField] protected Transform playerTarget;
     [SerializeField] protected GameObject enemyDropPrefab;
+    [SerializeField] protected GameObject enemyDropList;
 
     //Private references
     protected Seeker seeker;
@@ -58,6 +59,8 @@ public abstract class Enemy : MonoBehaviour
         hitbox = GetComponent<Collider2D>();
         collidersDamaged = new List<Collider2D>();
         playerTarget = PlayerControllerForces.Instance.gameObject.transform;
+
+        enemyDropList = GameObject.Find("Enemy Drops");
 
         isSleeping = false;
     }
@@ -122,7 +125,7 @@ public abstract class Enemy : MonoBehaviour
     {
         if (Random.Range(1, 100) <= 50)
         {
-            GameObject drop = Instantiate(enemyDropPrefab);
+            GameObject drop = Instantiate(enemyDropPrefab, enemyDropList.transform);
             drop.transform.position = this.transform.position;
         }
 

--- a/GrimsCoffinProject/Assets/Scripts/Enemies/Enemy.cs
+++ b/GrimsCoffinProject/Assets/Scripts/Enemies/Enemy.cs
@@ -21,6 +21,7 @@ public abstract class Enemy : MonoBehaviour
     [SerializeField] protected Transform enemyGFX;
     [SerializeField] protected GameObject enemy;
     [SerializeField] protected Transform playerTarget;
+    [SerializeField] protected GameObject enemyDropPrefab;
 
     //Private references
     protected Seeker seeker;
@@ -119,6 +120,12 @@ public abstract class Enemy : MonoBehaviour
     //Destroy enemy, used for when it dies and when it despawns
     public virtual void DestroyEnemy()
     {
+        if (Random.Range(1, 100) <= 50)
+        {
+            GameObject drop = Instantiate(enemyDropPrefab);
+            drop.transform.position = this.transform.position;
+        }
+
         this.gameObject.GetComponentInParent<EnemyManager>().RemoveActiveEnemy(this.gameObject);
         Destroy(this.gameObject);
     }

--- a/GrimsCoffinProject/Assets/Scripts/Enemies/EnemyDrop.cs
+++ b/GrimsCoffinProject/Assets/Scripts/Enemies/EnemyDrop.cs
@@ -1,0 +1,89 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemyDrop : MonoBehaviour
+{
+    public enum EnemyDropType
+    {
+        Health,
+        SpiritPower
+    }
+
+
+    [SerializeField] public EnemyDropType dropType;
+    [SerializeField] public float value = 10;
+
+    [SerializeField] private float speed = 15;
+
+    [SerializeField] private Color healthColor;
+    [SerializeField] private Color spiritPowerColor;
+
+    private bool collected;
+
+    private void Start()
+    {
+        if (Random.Range(1, 100) <= 50 && PlayerControllerForces.Instance.Data.canScytheThrow)
+        {
+            dropType = EnemyDropType.SpiritPower;
+        }
+
+        else
+        {
+            dropType = EnemyDropType.Health;
+        }
+
+        switch (dropType)
+        {
+            case EnemyDropType.Health:
+                GetComponent<SpriteRenderer>().color = healthColor;
+                break;
+
+            case EnemyDropType.SpiritPower:
+                GetComponent<SpriteRenderer>().color = spiritPowerColor;
+                value = 5;
+                break;
+        }
+    }
+
+    private void Update()
+    {
+        if (collected)
+        {
+            Debug.Log("Pickup Moving");
+            this.transform.position = Vector3.MoveTowards(transform.position, PlayerControllerForces.Instance.transform.position, speed * Time.deltaTime);
+        }
+
+        if (transform.position == PlayerControllerForces.Instance.transform.position)
+        {
+            CollectDrop();
+        }
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.gameObject.GetComponent<PlayerControllerForces>() != null)
+        {
+            Debug.Log("Pickup Collected");
+            collected = true;
+        }
+    }
+
+    private void CollectDrop()
+    {
+        switch (dropType)
+        {
+            case EnemyDropType.Health:
+                PlayerControllerForces.Instance.currentHP += value;
+                Mathf.Clamp(PlayerControllerForces.Instance.currentHP, 0, PlayerControllerForces.Instance.Data.maxHP);
+                break;
+
+            case EnemyDropType.SpiritPower:
+                PlayerControllerForces.Instance.currentSP += value;
+                Mathf.Clamp(PlayerControllerForces.Instance.currentSP, 0, PlayerControllerForces.Instance.Data.maxSP);
+                break;
+        }
+
+        Destroy(gameObject);
+    }
+}

--- a/GrimsCoffinProject/Assets/Scripts/Enemies/EnemyDrop.cs
+++ b/GrimsCoffinProject/Assets/Scripts/Enemies/EnemyDrop.cs
@@ -15,6 +15,8 @@ public class EnemyDrop : MonoBehaviour
     [SerializeField] public float value = 10;
 
     [SerializeField] private float speed = 15;
+    [SerializeField] private float lifetime = 3.5f;
+    private float lifetimeTimer;
 
     [SerializeField] private Color healthColor;
     [SerializeField] private Color spiritPowerColor;
@@ -44,6 +46,8 @@ public class EnemyDrop : MonoBehaviour
                 value = 5;
                 break;
         }
+
+        lifetimeTimer = 0;
     }
 
     private void Update()
@@ -52,6 +56,13 @@ public class EnemyDrop : MonoBehaviour
         {
             Debug.Log("Pickup Moving");
             this.transform.position = Vector3.MoveTowards(transform.position, PlayerControllerForces.Instance.transform.position, speed * Time.deltaTime);
+        }
+
+        else
+        {
+            lifetimeTimer += Time.deltaTime;
+            if (lifetimeTimer >= lifetime)
+                Destroy(gameObject);
         }
 
         if (transform.position == PlayerControllerForces.Instance.transform.position)

--- a/GrimsCoffinProject/Assets/Scripts/Enemies/EnemyDrop.cs.meta
+++ b/GrimsCoffinProject/Assets/Scripts/Enemies/EnemyDrop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a3cdfac1af519d4a94cdc77f6922a4b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GrimsCoffinProject/Assets/Scripts/LoadCutscene.cs
+++ b/GrimsCoffinProject/Assets/Scripts/LoadCutscene.cs
@@ -22,7 +22,7 @@ public class LoadCutscene : MonoBehaviour
     {
         if (other.gameObject.GetComponent<PlayerControllerForces>() != null)
         {
-            SceneManager.LoadScene(4);
+            SceneManager.LoadScene("Scene Transition Cutscene");
         }
     }
 }

--- a/GrimsCoffinProject/Assets/Scripts/PersistentDataManager.cs
+++ b/GrimsCoffinProject/Assets/Scripts/PersistentDataManager.cs
@@ -64,7 +64,7 @@ public class PersistentDataManager : MonoBehaviour
     void Start()
     {
         //If the player is in the cutscene between Onboarding and Denial Area, transition their stats
-        if (SceneManager.GetActiveScene().name == "CutScene")
+        if (SceneManager.GetActiveScene().name == "Scene Transition Cutscene")
             TransitionToDenialArea();
     }
 

--- a/GrimsCoffinProject/Assets/Scripts/SceneTransition/TransitionDoor.cs
+++ b/GrimsCoffinProject/Assets/Scripts/SceneTransition/TransitionDoor.cs
@@ -43,6 +43,8 @@ public class TransitionDoor : MonoBehaviour
     private EnemyManager enterEnemyMgr;
     [SerializeField]
     private EnemyManager exitEnemyMgr;
+    [SerializeField]
+    private GameObject enemyDropList;
 
     public Vector3 SpawnPos
     {
@@ -53,6 +55,7 @@ public class TransitionDoor : MonoBehaviour
     void Start()
     {
         spawnPos = transform.GetChild(0).position;
+        enemyDropList = GameObject.Find("Enemy Drops");
     }
 
     // Update is called once per frame
@@ -94,6 +97,11 @@ public class TransitionDoor : MonoBehaviour
             {
                 Debug.Log("Deleting Enemies");
                 exitEnemyMgr.DeleteEnemies();
+            }
+
+            foreach (Transform child in enemyDropList.transform)
+            {
+                Destroy(child.gameObject);
             }
         }
     }

--- a/GrimsCoffinProject/Assets/Scripts/SceneTransition/TransitionDoor.cs
+++ b/GrimsCoffinProject/Assets/Scripts/SceneTransition/TransitionDoor.cs
@@ -76,6 +76,7 @@ public class TransitionDoor : MonoBehaviour
     {
         if (collision.gameObject.CompareTag("Player"))
         {
+            PlayerControllerForces.Instance.Sleep(1.5f);
             if (areaEntering.GetComponent<Room>().roomIndex == 2 && SceneManager.GetActiveScene().name == "OnboardingLevel")
             {
                 PlayerControllerForces.Instance.Data.canDash = true;
@@ -108,7 +109,7 @@ public class TransitionDoor : MonoBehaviour
 
     IEnumerator Transition(Collider2D col)
     {
-        PlayerControllerForces.Instance.Sleep(2);
+        
         if (!areaEntering.activeInHierarchy)
         {
             areaEntering.SetActive(true);

--- a/GrimsCoffinProject/Assets/Scripts/UI Scripts/PauseScreenBehavior.cs
+++ b/GrimsCoffinProject/Assets/Scripts/UI Scripts/PauseScreenBehavior.cs
@@ -94,7 +94,7 @@ public class PauseScreenBehavior : MonoBehaviour
         EventSystem.current.SetSelectedGameObject(null);
         foreach (Room room in PersistentDataManager.Instance.rooms)
         {
-            if (room.gameObject.activeInHierarchy)
+            if (room.gameObject.activeInHierarchy && room.GetComponent<EnemyManager>() != null)
                 room.GetComponent<EnemyManager>().DeleteEnemies();
         }
         SceneManager.LoadScene("TitleScreen");

--- a/GrimsCoffinProject/ProjectSettings/EditorBuildSettings.asset
+++ b/GrimsCoffinProject/ProjectSettings/EditorBuildSettings.asset
@@ -26,4 +26,10 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Kevin's Test Scenes/MapPanning&Zooming.unity
     guid: 2fb6ae5a24672e146865ed2145608c78
+  - enabled: 1
+    path: Assets/Scenes/Boxi's Test Scene/Scene Transition Cutscene.unity
+    guid: 25d3ec4c2c762e94ebf8e1bdf9170f95
+  - enabled: 1
+    path: Assets/Scenes/Boxi's Test Scene/Lighting_Test.unity
+    guid: d65aabc3d13a7124e9b5d8f9e340e397
   m_configObjects: {}

--- a/GrimsCoffinProject/fmod_editor.log
+++ b/GrimsCoffinProject/fmod_editor.log
@@ -9,7 +9,7 @@
 [LOG] DownMix::init                            : done.
 [LOG] Thread::initThread                       : Init FMOD stream thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFB, Stack Size: 98304, Semaphore: No, Sleep Time: 10, Looping: Yes.
 [LOG] Thread::initThread                       : Init FMOD mixer thread. Affinity: 0x4000000000000001, Priority: 0xFFFF7FFA, Stack Size: 81920, Semaphore: No, Sleep Time: 0, Looping: Yes.
-[LOG] AsyncManager::init                       : manager 000001F53BA3F3B8 isAsync 0 updatePeriod 0.02
+[LOG] AsyncManager::init                       : manager 00000240E20E3D08 isAsync 0 updatePeriod 0.02
 [LOG] AsyncManager::init                       : done
 [LOG] PlaybackSystem::init                     : 
 [LOG] Thread::initThread                       : Init FMOD Studio sample load thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFD, Stack Size: 98304, Semaphore: No, Sleep Time: 1, Looping: No.
@@ -20,10 +20,3 @@
 [LOG] Manager::readBank                        : fileversion = 142, compatVersion = 140 (oldest = 44, newest = 142)
 [LOG] Manager::readBank                        : fileversion = 142, compatVersion = 140 (oldest = 44, newest = 142)
 [LOG] PlaybackSystem::acquireMasterBus         : Setting master channel group format to 6
-[LOG] Thread::callback                         : FMOD Studio bank load thread finished.
-[LOG] Thread::callback                         : FMOD Studio sample load thread finished.
-[LOG] LiveUpdate::release                      : 
-[LOG] LiveUpdate::reset                        : Reset connection (reason Disconnected)
-[LOG] Thread::callback                         : FMOD stream thread finished.
-[LOG] Thread::callback                         : FMOD mixer thread finished.
-[LOG] SystemI::close                           : Closed.


### PR DESCRIPTION
## Summarize what is being added
-Enemies now have a chance to drop HP or SP pickups when defeated
-When the player gets close to a pickup, it will travel to the player
-Once the pickup overlaps with the player, it will be collected and HP/SP will be replenished
-Pickups will also be deleted when transitioning between rooms
-Current probability is that items should have about a 50% chance of dropping, with a 50/50 split between SP and HP drops
-HP drops recover 10 Health, with SP drops recovering 5 SP (these can be changed later)
-Font updated to have a subtle drop shadow, improving Area Text readability

## Please describe how to test
-Open the build and start a new game
-Progress like normal, enemies should randomly drop pickups when killed
-Pickups have a lifetime of 3.5 seconds, and will despawn if not picked up in that time
-Spirit Power pickups should NOT spawn unless you have scythe throw unlocked

## Issue worked on
https://emotional-baggage.atlassian.net/jira/software/projects/GRIM/boards/1?selectedIssue=GRIM-148
https://emotional-baggage.atlassian.net/jira/software/projects/GRIM/boards/1?selectedIssue=GRIM-170
https://emotional-baggage.atlassian.net/jira/software/projects/GRIM/boards/1?selectedIssue=GRIM-169

## Link to Build
https://drive.google.com/file/d/12zLaVpHs7uC9fb5dGdB6cnNTwfBUTbOL/view?usp=sharing

## Link to Documentation
https://docs.google.com/document/d/1iZb2SRyBWoKc3UYMsVdhkGbx9wkAkkQ6/edit#heading=h.rxb49av1wz9l

## What Sprint is this due in?
Sprint 6