### PR TITLE
Feature/health upgrades

### DIFF
--- a/GrimsCoffinProject/Assets/Prefabs/Enemies/Enemy Drops/Enemy Drop.prefab
+++ b/GrimsCoffinProject/Assets/Prefabs/Enemies/Enemy Drops/Enemy Drop.prefab
@@ -1,5 +1,85 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3925902107405136972
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1461717910656351420}
+  - component: {fileID: 651487086909269893}
+  - component: {fileID: 3973037433677382994}
+  m_Layer: 0
+  m_Name: Pickup Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1461717910656351420
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3925902107405136972}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8638745306620307969}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &651487086909269893
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3925902107405136972}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.5
+--- !u!114 &3973037433677382994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3925902107405136972}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ee1474fc8b91eff47aeb627ef43b6bfd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &5018094658481689379
 GameObject:
   m_ObjectHideFlags: 0
@@ -31,7 +111,8 @@ Transform:
   m_LocalPosition: {x: -12.713, y: 0.166, z: 0}
   m_LocalScale: {x: 0.6, y: 0.6, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1461717910656351420}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &4684179120831987743
@@ -133,8 +214,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0a3cdfac1af519d4a94cdc77f6922a4b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  dropType: 0
+  value: 10
+  speed: 10
+  lifetime: 3.5
   healthColor: {r: 1, g: 0, b: 0, a: 0.9411765}
   spiritPowerColor: {r: 0.61960787, g: 0.9372549, b: 0.94509804, a: 0.9411765}
-  dropType: 0
-  speed: 10
-  value: 10

--- a/GrimsCoffinProject/Assets/Prefabs/Health Upgrade.prefab
+++ b/GrimsCoffinProject/Assets/Prefabs/Health Upgrade.prefab
@@ -1,0 +1,163 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &346896658569138220
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6390151642651715791}
+  - component: {fileID: 437079286211835989}
+  - component: {fileID: 4264736989294501536}
+  - component: {fileID: 3064733572416489394}
+  - component: {fileID: 1611048090795030402}
+  m_Layer: 0
+  m_Name: Health Upgrade
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6390151642651715791
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 346896658569138220}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -17.900002, y: 0.4836, z: 0}
+  m_LocalScale: {x: 1, y: 0.5136, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &437079286211835989
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 346896658569138220}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -9095717837082945937, guid: 207ee8102dd4143d288186ef0be518ee, type: 3}
+  m_Color: {r: 0.45573092, g: 1, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 1
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &4264736989294501536
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 346896658569138220}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25c1768e24fc04e4b95128abb6107a9a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  promptTrigger: {fileID: 3064733572416489394}
+  interaction: 3
+  interactionText: Collect
+  time: 0
+--- !u!61 &3064733572416489394
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 346896658569138220}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.01683712, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 2}
+    newSize: {x: 1, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.6024075, y: 2}
+  m_EdgeRadius: 0
+--- !u!114 &1611048090795030402
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 346896658569138220}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f36a364f91acca14783aed7323460a0b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  collectableID: 0

--- a/GrimsCoffinProject/Assets/Prefabs/Health Upgrade.prefab.meta
+++ b/GrimsCoffinProject/Assets/Prefabs/Health Upgrade.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d65ea86484dee8944bf7b82442194a88
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/HealthCollectable.prefab
+++ b/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/HealthCollectable.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &702137595701392064
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4295161823587100461}
+  - component: {fileID: 7507408673580701717}
+  - component: {fileID: 3276409495896595285}
+  m_Layer: 5
+  m_Name: HealthCollectable
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4295161823587100461
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 702137595701392064}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7507408673580701717
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 702137595701392064}
+  m_CullTransparentMesh: 1
+--- !u!114 &3276409495896595285
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 702137595701392064}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.23358655, g: 1, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/HealthCollectable.prefab.meta
+++ b/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/HealthCollectable.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 273a36034682c1c48885d886fa007f33
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/PlayerStats.prefab
+++ b/GrimsCoffinProject/Assets/Prefabs/UI Prefabs/PlayerStats.prefab
@@ -75,6 +75,68 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4090981897108327902
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4983049993199099139}
+  - component: {fileID: 8085458609310116915}
+  m_Layer: 5
+  m_Name: HealthCollectables
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4983049993199099139
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4090981897108327902}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3611862899468279041}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -733.66907, y: 496.9}
+  m_SizeDelta: {x: 46.6617, y: 43.9109}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8085458609310116915
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4090981897108327902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 3
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &4399067848955728466
 GameObject:
   m_ObjectHideFlags: 0
@@ -331,6 +393,7 @@ RectTransform:
   - {fileID: 1680433181356316002}
   - {fileID: 3603470675022046363}
   - {fileID: 2963048123141768356}
+  - {fileID: 4983049993199099139}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -355,6 +418,8 @@ MonoBehaviour:
   healthBarFill: {fileID: 4061709345956278956}
   spiritBar: {fileID: 3757820558949364294}
   spiritBarFill: {fileID: 8906958385532880086}
+  healthCollectablePrefab: {fileID: 702137595701392064, guid: 273a36034682c1c48885d886fa007f33, type: 3}
+  healthCollecatbleList: {fileID: 4090981897108327902}
 --- !u!1 &7180158702611413615
 GameObject:
   m_ObjectHideFlags: 0

--- a/GrimsCoffinProject/Assets/Scripts/Enemies/EnemyDrop.cs
+++ b/GrimsCoffinProject/Assets/Scripts/Enemies/EnemyDrop.cs
@@ -64,11 +64,6 @@ public class EnemyDrop : MonoBehaviour
             if (lifetimeTimer >= lifetime)
                 Destroy(gameObject);
         }
-
-        if (transform.position == PlayerControllerForces.Instance.transform.position)
-        {
-            CollectDrop();
-        }
     }
 
     private void OnTriggerEnter2D(Collider2D collision)
@@ -80,7 +75,7 @@ public class EnemyDrop : MonoBehaviour
         }
     }
 
-    private void CollectDrop()
+    public void CollectDrop()
     {
         switch (dropType)
         {

--- a/GrimsCoffinProject/Assets/Scripts/Enemies/EnemyDropPickup.cs
+++ b/GrimsCoffinProject/Assets/Scripts/Enemies/EnemyDropPickup.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemyDropPickup : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.gameObject.GetComponent<PlayerControllerForces>() != null)
+        {
+            this.transform.parent.GetComponent<EnemyDrop>().CollectDrop();
+        }
+    }
+}

--- a/GrimsCoffinProject/Assets/Scripts/Enemies/EnemyDropPickup.cs.meta
+++ b/GrimsCoffinProject/Assets/Scripts/Enemies/EnemyDropPickup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee1474fc8b91eff47aeb627ef43b6bfd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GrimsCoffinProject/Assets/Scripts/HealthUpgrade.cs
+++ b/GrimsCoffinProject/Assets/Scripts/HealthUpgrade.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class HealthUpgrade : Interactable
+{
+    [SerializeField] public int collectableID;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        if (PersistentDataManager.Instance.HealthUpgradesCollected()[collectableID])
+            Destroy(gameObject);
+
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    public override void PerformInteraction()
+    {
+        PersistentDataManager.Instance.CollectHealthUpgrade(collectableID);
+        Destroy(this.gameObject);
+    }
+}

--- a/GrimsCoffinProject/Assets/Scripts/HealthUpgrade.cs.meta
+++ b/GrimsCoffinProject/Assets/Scripts/HealthUpgrade.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f36a364f91acca14783aed7323460a0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GrimsCoffinProject/Assets/Scripts/PersistentDataManager.cs
+++ b/GrimsCoffinProject/Assets/Scripts/PersistentDataManager.cs
@@ -159,6 +159,7 @@ public class PersistentDataManager : MonoBehaviour
             Mathf.Clamp(collectablesHeld, 0, 100);
 
             PlayerPrefs.SetInt("HealthCollectablesHeld", collectablesHeld);
+            UIManager.Instance.ShowAbilityUnlock("Max Health Increased");
             UIManager.Instance.RemoveHealthCollectables();
         }
 

--- a/GrimsCoffinProject/Assets/Scripts/PersistentDataManager.cs
+++ b/GrimsCoffinProject/Assets/Scripts/PersistentDataManager.cs
@@ -3,6 +3,7 @@ using Pathfinding.Ionic.Zip;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor.Rendering;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -34,11 +35,14 @@ public class PersistentDataManager : MonoBehaviour
     public bool CanScytheThrow { get { return PlayerPrefs.GetInt("CanScytheThrow", 0) == 1; } }
     public bool CanViewMap { get { return PlayerPrefs.GetInt("CanViewMap", 0) == 1; } }
 
+    public int HealthCollectablesHeld { get { return PlayerPrefs.GetInt("HealthCollectablesHeld", 0); } }
+
     //Whether or not the Player is entering the Denial Area Scene for the first time
     public bool FirstTimeInDenial { get { return PlayerPrefs.GetInt("FirstTimeDenial", 1) == 1; } }
 
     //List of rooms in the scene
     [SerializeField] public List<Room> rooms;
+    [SerializeField] public List<HealthUpgrade> healthUpgrades;
 
     //Default values to spawn the player at when a New Game is started
     [SerializeField] private float defaultXPos = 0;
@@ -137,6 +141,23 @@ public class PersistentDataManager : MonoBehaviour
             }
                 
         }
+        
+        //Trade in health collectables for health upgrade
+        else if (spirit.spiritID == Spirit.SpiritID.HealthSpirit && spirit.spiritState == Spirit.SpiritState.Idle && PersistentDataManager.Instance.HealthCollectablesHeld >= 3)
+        {
+            PlayerControllerForces.Instance.Data.maxHP += 15;
+            PlayerControllerForces.Instance.currentHP = PlayerControllerForces.Instance.Data.maxHP;
+            PlayerPrefs.SetFloat("MaxHP", PlayerControllerForces.Instance.Data.maxHP);
+
+            int collectablesHeld = HealthCollectablesHeld;
+
+            collectablesHeld -= 3;
+            Mathf.Clamp(collectablesHeld, 0, 100);
+
+            PlayerPrefs.SetInt("HealthCollectablesHeld", collectablesHeld);
+            UIManager.Instance.RemoveHealthCollectables();
+        }
+
         PlayerPrefs.SetString(spirit.spiritID.ToString(), spirit.spiritState.ToString());
     }
 
@@ -214,11 +235,18 @@ public class PersistentDataManager : MonoBehaviour
         PlayerPrefs.SetString("ScytheThrowSpirit", "Uncollected");
         PlayerPrefs.SetString("HealthSpirit", "Uncollected");
 
+        PlayerPrefs.SetInt("HealthCollectablesHeld", 0);
+
         //Clear Onboarding Map Data
         for (int i = 0; i < 25; i++)
         {
             PlayerPrefs.SetInt("LevelRoom" + i, 0);
         } 
+
+        for (int i = 0; i < 25; i++)
+        {
+            PlayerPrefs.SetInt("HealthCollectable" + 1, 0);
+        }
     }
 
     //Transition between Onboarding Level and Denial Area
@@ -260,5 +288,27 @@ public class PersistentDataManager : MonoBehaviour
         }
 
         return result;
+    }
+
+    public List<bool> HealthUpgradesCollected()
+    {
+        List<bool> result = new List<bool>();
+        foreach(HealthUpgrade collectable in healthUpgrades)
+        {
+            if (PlayerPrefs.GetInt("HealthCollectable" + collectable.collectableID) == 1)
+                result.Add(true);
+
+            else
+                result.Add(false);
+        }
+
+        return result;
+    }
+
+    public void CollectHealthUpgrade(int collectableID)
+    {
+        UIManager.Instance.AddHealthCollectable();
+        PlayerPrefs.SetInt("HealthCollectablesHeld", HealthCollectablesHeld + 1);
+        PlayerPrefs.SetInt("HealthCollectable" + collectableID, 1);
     }
 }

--- a/GrimsCoffinProject/Assets/Scripts/UI Scripts/PlayerStatsUI.cs
+++ b/GrimsCoffinProject/Assets/Scripts/UI Scripts/PlayerStatsUI.cs
@@ -12,6 +12,17 @@ public class PlayerStatsUI : MonoBehaviour
     public RectTransform spiritBar;
     public Image spiritBarFill;
 
+    [SerializeField] private GameObject healthCollectablePrefab;
+    [SerializeField] private GameObject healthCollecatbleList;
+
+    private void Start()
+    {
+        for (int i = 0; i < PersistentDataManager.Instance.HealthCollectablesHeld; i++)
+        {
+            AddHealthCollectable();
+        }
+    }
+
     // Update is called once per frame
     void Update()
     {
@@ -29,5 +40,18 @@ public class PlayerStatsUI : MonoBehaviour
     private bool LowHealth()
     {
         return (player.currentHP / player.Data.maxHP) < .25f;
+    }
+
+    public void AddHealthCollectable()
+    {
+        Instantiate(healthCollectablePrefab, healthCollecatbleList.transform);
+    }
+
+    public void RemoveHealthCollectables()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            Destroy(healthCollecatbleList.transform.GetChild(i).gameObject);
+        }
     }
 }

--- a/GrimsCoffinProject/Assets/Scripts/UI Scripts/UIManager.cs
+++ b/GrimsCoffinProject/Assets/Scripts/UI Scripts/UIManager.cs
@@ -107,6 +107,18 @@ public class UIManager : MonoBehaviour
         Time.timeScale = 0.0f;
     }
 
+    public void AddHealthCollectable()
+    {
+        PlayerStatsUI playerStats = gameUI.GetComponentInChildren<PlayerStatsUI>();
+        playerStats.AddHealthCollectable();
+    }
+
+    public void RemoveHealthCollectables()
+    {
+        PlayerStatsUI playerStats = gameUI.GetComponentInChildren<PlayerStatsUI>();
+        playerStats.RemoveHealthCollectables();
+    }
+
     //Toggle minimap on/off
     public void ToggleMap()
     {


### PR DESCRIPTION
## Summarize what is being added
-Health collectables added to increase max HP with the health spirit
-3 collectables added to denial level based off of level design sketch
-UI added to show how many health collectables are currently held
-Enemy drops tweaked to have more forgiving collision for collection
-Player can trade 3 health collectables for another +15 Max HP at the health spirit
-Health upgrades tracked with persistent data to only allow one time collection

## Please describe how to test
-Open the build and run the game, get to the denial area
-Collect the health spirit, then look for the 3 health collectables
-One is in the room above the large room (with the double jump ledge)
-One is at the dead end with the spikes to dash past
-One is at the top of the room before where you meet the Scythe Throw spirit
-Once you collect all three collectables, return to equilibrium and talk to the health spirit, you should get another health upgrade

## Issue worked on
https://emotional-baggage.atlassian.net/jira/software/projects/GRIM/boards/1?selectedIssue=GRIM-171

## Link to Build
https://drive.google.com/file/d/1ijr3Tn25Gw2iKRzu-dO2XL_2wcIqTebd/view?usp=drive_link

## Link to Documentation
https://docs.google.com/document/d/1iZb2SRyBWoKc3UYMsVdhkGbx9wkAkkQ6/edit#heading=h.75dqa4vjkxsw

## What Sprint is this due in?
Sprint 6